### PR TITLE
Fix Faraday JSON parsing middleware and spec mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 ## [Unreleased]
 
+# [0.1.2] - 2021-06-04
+
+### Fixed
+
+- Fix JSON parsing to use Faraday middleware only
+
 ## [0.1.1] - 2021-06-01
+
+### Added
 
 - Add Dashboard/Folder search capabilities
 

--- a/lib/grafana/client/base_client.rb
+++ b/lib/grafana/client/base_client.rb
@@ -24,20 +24,20 @@ module Grafana
 
     def get(url, **options)
       # TODO: error handling
-      JSON.parse(@conn.get(url, **options).body)
+      @conn.get(url, **options).body
     end
 
     def post(url, body, **options)
       response = @conn.post(url, body, **options)
 
       # TODO: handle errors in the response
-      JSON.parse(response.body)
+      response.body
     end
 
     def delete(url, **options)
       response = @conn.delete(url, **options)
 
-      JSON.parse(response.body)
+      response.body
     end
   end
 end

--- a/lib/grafana/client/version.rb
+++ b/lib/grafana/client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Grafana
-  CLIENT_VERSION = "0.1.1"
+  CLIENT_VERSION = "0.1.2"
 end

--- a/spec/grafana/modules/alert_spec.rb
+++ b/spec/grafana/modules/alert_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Grafana::Modules::Alert do
   describe "#alerts" do
     it "requests all alerts if no query params" do
       stub = stub_request(:get, "https://test.grafana.io/api/alerts?state=ALL")
-        .and_return(body: alerts_list.to_json)
+        .and_return(body: alerts_list.to_json, headers: { content_type: 'application/json' })
 
       response = test_client.alerts
 
@@ -63,7 +63,7 @@ RSpec.describe Grafana::Modules::Alert do
 
     it "requests with panel id" do
       stub = stub_request(:get, "https://test.grafana.io/api/alerts?panelId=1&state=ALL")
-        .and_return(body: alerts_list.to_json)
+        .and_return(body: alerts_list.to_json, headers: { content_type: 'application/json' })
 
       test_client.alerts(panel_id: 1)
 
@@ -73,7 +73,7 @@ RSpec.describe Grafana::Modules::Alert do
     context "with folder ids" do
       it "requests singular" do
         stub = stub_request(:get, "https://test.grafana.io/api/alerts?folderId=1&state=ALL")
-          .and_return(body: alerts_list.to_json)
+          .and_return(body: alerts_list.to_json, headers: { content_type: 'application/json' })
 
         test_client.alerts(folder_id: 1)
 
@@ -82,7 +82,7 @@ RSpec.describe Grafana::Modules::Alert do
 
       it "requests multiple" do
         stub = stub_request(:get, "https://test.grafana.io/api/alerts?folderId=0&folderId=1&state=ALL")
-          .and_return(body: alerts_list.to_json)
+          .and_return(body: alerts_list.to_json, headers: { content_type: 'application/json' })
 
         test_client.alerts(folder_id: [0, 1])
 
@@ -93,7 +93,7 @@ RSpec.describe Grafana::Modules::Alert do
     context "with dashboard ids" do
       it "requests singular" do
         stub = stub_request(:get, "https://test.grafana.io/api/alerts?dashboardId=1&state=ALL")
-          .and_return(body: alerts_list.to_json)
+          .and_return(body: alerts_list.to_json, headers: { content_type: 'application/json' })
 
         test_client.alerts(dashboard_id: 1)
 
@@ -102,7 +102,7 @@ RSpec.describe Grafana::Modules::Alert do
 
       it "requests multiple" do
         stub = stub_request(:get, "https://test.grafana.io/api/alerts?dashboardId=0&dashboardId=1&state=ALL")
-          .and_return(body: alerts_list.to_json)
+          .and_return(body: alerts_list.to_json, headers: { content_type: 'application/json' })
 
         test_client.alerts(dashboard_id: [0, 1])
 
@@ -120,7 +120,7 @@ RSpec.describe Grafana::Modules::Alert do
 
     it "returns a dashboard from the specified uid" do
       stub = stub_request(:get, "https://test.grafana.io/api/alerts/1")
-        .and_return(body: example_alert.to_json)
+        .and_return(body: example_alert.to_json, headers: { content_type: 'application/json' })
 
       alert = subject.alert(id: 1)
 
@@ -139,7 +139,8 @@ RSpec.describe Grafana::Modules::Alert do
     it "requests a pause for the alert" do
       stub = stub_request(:post, "https://test.grafana.io/api/alerts/1/pause")
         .with(body: { paused: true }.to_json)
-        .and_return(body: { "alertId": 1, "state": "Paused", "message": "alert paused" }.to_json)
+        .and_return(body: { "alertId": 1, "state": "Paused", "message": "alert paused" }.to_json, 
+                    headers: { content_type: 'application/json' })
 
       pause = subject.pause_alert(id: 1)
 
@@ -149,7 +150,8 @@ RSpec.describe Grafana::Modules::Alert do
     it "requests an un pause for the alert if paused = false" do
       stub = stub_request(:post, "https://test.grafana.io/api/alerts/1/pause")
         .with(body: { paused: false }.to_json)
-        .and_return(body: { "alertId": 1, "state": "Paused", "message": "alert paused" }.to_json)
+        .and_return(body: { "alertId": 1, "state": "Paused", "message": "alert paused" }.to_json,
+                    headers: { content_type: 'application/json' })
 
       pause = subject.pause_alert(id: 1, paused: false)
 
@@ -167,7 +169,8 @@ RSpec.describe Grafana::Modules::Alert do
     it "requests an unpause for the alert" do
       stub = stub_request(:post, "https://test.grafana.io/api/alerts/1/pause")
         .with(body: { paused: false }.to_json)
-        .and_return(body: { "alertId": 1, "state": "Paused", "message": "alert paused" }.to_json)
+        .and_return(body: { "alertId": 1, "state": "Paused", "message": "alert paused" }.to_json,
+                    headers: { content_type: 'application/json' })
 
       pause = subject.pause_alert(id: 1, paused: false)
 

--- a/spec/grafana/modules/dashboard_spec.rb
+++ b/spec/grafana/modules/dashboard_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Grafana::Modules::Dashboard do
   describe "#home_dashboard" do
     it "calls the home dashboard api" do
       stub = stub_request(:get, "https://test.grafana.io/api/dashboards/home")
-        .to_return(body: example_dashboard.to_json)
+        .to_return(body: example_dashboard.to_json, headers: {content_type: 'application/json'})
 
       dashboard = subject.home_dashboard
 
@@ -76,7 +76,7 @@ RSpec.describe Grafana::Modules::Dashboard do
 
       stub = stub_request(:post, "https://test.grafana.io/api/dashboards/db")
         .with(body: request_body.to_json)
-        .and_return(status: 200, body: response_body.to_json)
+        .and_return(status: 200, body: response_body.to_json, headers: {content_type: 'application/json'})
 
       response = subject.create_dashboard(dashboard: example_dashboard, **request_options)
 
@@ -110,11 +110,11 @@ RSpec.describe Grafana::Modules::Dashboard do
       }
 
       get_stub = stub_request(:get, "https://test.grafana.io/api/dashboards/uid/testuid")
-        .and_return(body: example_dashboard.to_json)
+        .and_return(body: example_dashboard.to_json, headers: {content_type: 'application/json'})
 
       update_stub = stub_request(:post, "https://test.grafana.io/api/dashboards/db")
         .with(body: request_body.to_json)
-        .and_return(status: 200, body: response_body.to_json)
+        .and_return(status: 200, body: response_body.to_json, headers: {content_type: 'application/json'})
 
       response = subject.update_dashboard(uid: 'testuid', **request_options)
 
@@ -149,7 +149,7 @@ RSpec.describe Grafana::Modules::Dashboard do
 
       stub = stub_request(:post, "https://test.grafana.io/api/dashboards/db")
         .with(body: request_body.to_json)
-        .and_return(status: 200, body: response_body.to_json)
+        .and_return(status: 200, body: response_body.to_json, headers: {content_type: 'application/json'})
 
       response = subject.overwrite_dashboard(dashboard: example_dashboard, **request_options)
 
@@ -167,7 +167,7 @@ RSpec.describe Grafana::Modules::Dashboard do
 
     it "returns a dashboard from the specified uid" do
       stub = stub_request(:get, "https://test.grafana.io/api/dashboards/uid/testuid")
-        .and_return(body: example_dashboard.to_json)
+        .and_return(body: example_dashboard.to_json, headers: {content_type: 'application/json'})
 
       dashboard = subject.dashboard(uid: 'testuid')
 
@@ -185,7 +185,8 @@ RSpec.describe Grafana::Modules::Dashboard do
 
     it "submits API request to delete w/ sepcified UID" do
       stub = stub_request(:delete, "https://test.grafana.io/api/dashboards/uid/testuid")
-        .and_return(body: { "title": "Production Overview", "message": "Dashboard Production Overview deleted", "id": 2 }.to_json)
+        .and_return(body: { "title": "Production Overview", "message": "Dashboard Production Overview deleted", "id": 2 }.to_json,
+                    headers: {content_type: 'application/json'})
 
       subject.delete_dashboard(uid: 'testuid')
 
@@ -207,7 +208,7 @@ RSpec.describe Grafana::Modules::Dashboard do
       ]
 
       stub = stub_request(:get, "https://test.grafana.io/api/dashboards/tags")
-        .and_return(body: tags_response.to_json)
+        .and_return(body: tags_response.to_json, headers: {content_type: 'application/json'})
 
       response = subject.dashboard_tags
 


### PR DESCRIPTION
Faraday JSON parsing required a `Content-Type` header, which was not provided in the specs. This caused parsing to be attempted twice when the header was provided, resulting in `TypeError` on the second attempt.